### PR TITLE
Fix for modules using same config name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,21 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'terminal-notifier'
-  gem 'terminal-notifier-guard'
-  gem 'pry'
-  gem 'pry-nav'
+  gem 'terminal-notifier', '1.6.2'
+  gem 'terminal-notifier-guard', '1.6.4'
+  gem 'pry', '0.10.1'
+  gem 'pry-nav', '0.2.4'
 end
 
 group :test do
-  gem 'rake'
-  gem 'rspec'
-  gem 'guard-rspec'
-  gem 'coveralls', require: false
+  gem 'rake', '10.4.2'
+  gem 'rspec', '3.2.0'
+
+  gem 'tins', '1.3.5' # coveralls dependency
+  gem 'term-ansicolor', '1.3.0' # coveralls dependency
+  gem 'rb-fsevent', '0.9.4' # guard-rspec dependency
+  gem 'rb-inotify', '0.9.5' # guard-rspec dependency
+
+  gem 'guard-rspec', '4.5.0'
+  gem 'coveralls', '0.7.11', require: false
 end

--- a/lib/configureasy/configurable.rb
+++ b/lib/configureasy/configurable.rb
@@ -61,10 +61,14 @@ module Configureasy::Configurable
   private
 
   def _configurable_init(method_name, filename)
-    @@configurables[_configurable_key(method_name)] = { filename: filename, payload: nil }
-    unless self.class.respond_to? method_name
-      self.class.send(:define_method, method_name) { _configurable_for(method_name) }
-      self.class.send(:define_method, "#{method_name}_reload!") { _configurable_reload(method_name) }
+    @@configurables[_configurable_key(method_name)] = { filename: filename,
+                                                        payload: nil }
+    return if self.class.respond_to? method_name
+    self.class.send(:define_method, method_name) do
+      _configurable_for(method_name)
+    end
+    self.class.send(:define_method, "#{method_name}_reload!") do
+      _configurable_reload(method_name)
     end
   end
 
@@ -77,11 +81,13 @@ module Configureasy::Configurable
   end
 
   def _configurable_for(method_name) # :nodoc:
-    _configurable_hash(method_name)[:payload] || _configurable_reload(method_name)
+    _configurable_hash(method_name)[:payload] ||
+      _configurable_reload(method_name)
   end
 
   def _configurable_reload(method_name) # :nodoc:
-    _configurable_hash(method_name)[:payload] = Configureasy::ConfigParser.new(_configurable_hash(method_name)[:filename]).as_config
+    filename = _configurable_hash(method_name)[:filename]
+    config = Configureasy::ConfigParser.new(filename).as_config
+    _configurable_hash(method_name)[:payload] = config
   end
-
 end

--- a/spec/lib/configureasy/configurable_spec.rb
+++ b/spec/lib/configureasy/configurable_spec.rb
@@ -1,3 +1,5 @@
+#encoding: utf-8
+
 require 'spec_helper'
 
 describe Configureasy::Configurable do

--- a/spec/lib/configureasy/configurable_spec.rb
+++ b/spec/lib/configureasy/configurable_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
-
 describe Configureasy::Configurable do
   before(:each) do
     allow(File).to receive(:exist?) { true }
-    allow(YAML).to receive(:load_file) { {'works' => 'true'} }
+    allow(YAML).to receive(:load_file) { { 'works' => 'true' } }
   end
 
-  context "when I have two modules with same config name" do
+  context 'when I have two modules with same config name' do
     before do
       module Foo
         include Configureasy
@@ -17,9 +16,13 @@ describe Configureasy::Configurable do
         include Configureasy
         load_config :bar, as: :config
       end
-      expect(YAML).to receive(:load_file).with('./config/foo.yml') { {'name' => 'andré'} }
-      expect(YAML).to receive(:load_file).with('./config/bar.yml') { {'name' => 'rodrigo'} }
-   end
+      expect(YAML).to receive(:load_file).with('./config/foo.yml') do
+        { 'name' => 'andré' }
+      end
+      expect(YAML).to receive(:load_file).with('./config/bar.yml') do
+        { 'name' => 'rodrigo' }
+      end
+    end
 
     it 'has different outputs' do
       expect(Foo.config).not_to eq(Bar.config)
@@ -69,7 +72,7 @@ describe Configureasy::Configurable do
       end
     end
 
-    it "load config content into config method" do
+    it 'load config content into config method' do
       expect(dumb_class).to respond_to :config
       expect(dumb_class.config.works).to eq('true')
     end
@@ -83,10 +86,9 @@ describe Configureasy::Configurable do
       end
     end
 
-    it "load config with filename into config method" do
+    it 'load config with filename into config method' do
       expect(dumb_class).to respond_to :config
       expect(dumb_class.config.works).to eq('true')
     end
   end
-
 end

--- a/spec/lib/configureasy/configurable_spec.rb
+++ b/spec/lib/configureasy/configurable_spec.rb
@@ -1,4 +1,4 @@
-#encoding: utf-8
+# encoding: utf-8
 
 require 'spec_helper'
 

--- a/spec/lib/configureasy/configurable_spec.rb
+++ b/spec/lib/configureasy/configurable_spec.rb
@@ -1,9 +1,29 @@
 require 'spec_helper'
 
+
 describe Configureasy::Configurable do
   before(:each) do
     allow(File).to receive(:exist?) { true }
     allow(YAML).to receive(:load_file) { {'works' => 'true'} }
+  end
+
+  context "when I have two modules with same config name" do
+    before do
+      module Foo
+        include Configureasy
+        load_config :foo, as: :config
+      end
+      module Bar
+        include Configureasy
+        load_config :bar, as: :config
+      end
+      expect(YAML).to receive(:load_file).with('./config/foo.yml') { {'name' => 'andré'} }
+      expect(YAML).to receive(:load_file).with('./config/bar.yml') { {'name' => 'rodrigo'} }
+   end
+
+    it 'has different outputs' do
+      expect(Foo.config).not_to eq(Bar.config)
+    end
   end
 
   describe '.load_config' do


### PR DESCRIPTION
When using Configureasy on Modules and declaring same config name on different modules, we're receiving the value of the last config invoked, across all modules.